### PR TITLE
TransportArbitrator: implement hasMessage

### DIFF
--- a/erpc_c/infra/erpc_transport_arbitrator.cpp
+++ b/erpc_c/infra/erpc_transport_arbitrator.cpp
@@ -46,6 +46,11 @@ void TransportArbitrator::setCrc16(Crc16 *crcImpl)
     m_sharedTransport->setCrc16(crcImpl);
 }
 
+bool TransportArbitrator::hasMessage(void)
+{
+    return m_sharedTransport->hasMessage();
+}
+
 erpc_status_t TransportArbitrator::receive(MessageBuffer *message)
 {
     assert(m_sharedTransport && "shared transport is not set");

--- a/erpc_c/infra/erpc_transport_arbitrator.h
+++ b/erpc_c/infra/erpc_transport_arbitrator.h
@@ -97,6 +97,11 @@ public:
      */
     virtual void setCrc16(Crc16 *crcImpl);
 
+    /*
+     * Tells clients if the transport has a message available
+     */
+    virtual bool hasMessage(void);
+
 protected:
     Transport *m_sharedTransport; //!< Transport being shared through this arbitrator.
     Codec *m_codec;               //!< Codec used to read incoming message headers.


### PR DESCRIPTION
Call through to the hasMessage method of the shared transport rather
than inheriting the base class hasMessage which always just returns
true. Doing this prevents erpc_server_poll() from getting stuck calling
the transport's receive() method when there are no messages to receive.